### PR TITLE
Moving hash check inline for downloaded files

### DIFF
--- a/one.lfa.updater.app/version.properties
+++ b/one.lfa.updater.app/version.properties
@@ -1,3 +1,3 @@
 #
-#Thu Jul 23 13:42:32 UTC 2020
-versionCode=1171
+#Fri Sep 04 17:31:16 AEST 2020
+versionCode=1211

--- a/one.lfa.updater.inventory.vanilla/src/main/java/one/lfa/updater/inventory/vanilla/tasks/InventoryTaskAPKFetchInstall.kt
+++ b/one.lfa.updater.inventory.vanilla/src/main/java/one/lfa/updater/inventory/vanilla/tasks/InventoryTaskAPKFetchInstall.kt
@@ -19,7 +19,8 @@ object InventoryTaskAPKFetchInstall {
         InventoryTaskFileDownloadRequest(
           uri = request.downloadURI,
           retries = request.downloadRetries,
-          outputFile = request.apkFile))
+          outputFile = request.apkFile,
+          expectedHash = request.hash))
         .flatMap {
           InventoryTaskFileVerify.createFailing(
             file = request.apkFile,

--- a/one.lfa.updater.inventory.vanilla/src/main/java/one/lfa/updater/inventory/vanilla/tasks/InventoryTaskFileDownloadRequest.kt
+++ b/one.lfa.updater.inventory.vanilla/src/main/java/one/lfa/updater/inventory/vanilla/tasks/InventoryTaskFileDownloadRequest.kt
@@ -1,6 +1,7 @@
 package one.lfa.updater.inventory.vanilla.tasks
 
 import one.lfa.updater.inventory.api.InventoryProgressValue
+import one.lfa.updater.repository.api.Hash
 import java.io.File
 import java.net.URI
 
@@ -8,4 +9,5 @@ data class InventoryTaskFileDownloadRequest(
   val progressMajor: InventoryProgressValue? = null,
   val uri: URI,
   val retries: Int,
-  val outputFile: File)
+  val outputFile: File,
+  val expectedHash: Hash)

--- a/one.lfa.updater.tests/src/main/java/au/org/libraryforall/updater/tests/tasks/InventoryTaskFileDownloadTest.kt
+++ b/one.lfa.updater.tests/src/main/java/au/org/libraryforall/updater/tests/tasks/InventoryTaskFileDownloadTest.kt
@@ -18,6 +18,7 @@ import one.lfa.updater.inventory.vanilla.tasks.InventoryTaskExecutionType
 import one.lfa.updater.inventory.vanilla.tasks.InventoryTaskFileDownload
 import one.lfa.updater.inventory.vanilla.tasks.InventoryTaskFileDownloadRequest
 import one.lfa.updater.inventory.vanilla.tasks.InventoryTaskResult
+import one.lfa.updater.repository.api.Hash
 import one.lfa.updater.services.api.ServiceDirectory
 import org.junit.Assert
 import org.junit.Before
@@ -40,6 +41,7 @@ class InventoryTaskFileDownloadTest {
   private lateinit var progress: MutableList<InventoryProgress>
   private lateinit var serviceDirectory: ServiceDirectoryType
   private lateinit var tempDir: File
+  private lateinit var fileHash: Hash
 
   @Before
   fun testSetup() {
@@ -88,6 +90,8 @@ class InventoryTaskFileDownloadTest {
         override val onProgress: (InventoryProgress) -> Unit
           get() = { progress -> this@InventoryTaskFileDownloadTest.progress.add(progress) }
       }
+
+    this.fileHash = Hash("2d8bd7d9bb5f85ba643f0110d50cb506a1fe439e769a22503193ea6046bb87f7")
   }
 
   /**
@@ -125,7 +129,8 @@ class InventoryTaskFileDownloadTest {
         progressMajor = null,
         uri = URI.create("http://www.example.com/0.apk"),
         retries = 1,
-        outputFile = outputFile)
+        outputFile = outputFile,
+        expectedHash = fileHash)
 
     val result =
       InventoryTaskFileDownload.create(request)
@@ -230,7 +235,8 @@ class InventoryTaskFileDownloadTest {
         progressMajor = null,
         uri = URI.create("http://www.example.com/0.apk"),
         retries = 3,
-        outputFile = outputFile)
+        outputFile = outputFile,
+        expectedHash = fileHash)
 
     val result =
       InventoryTaskFileDownload.create(request)
@@ -353,7 +359,8 @@ class InventoryTaskFileDownloadTest {
         progressMajor = null,
         uri = URI.create("http://www.example.com/0.apk"),
         retries = 3,
-        outputFile = outputFile)
+        outputFile = outputFile,
+        expectedHash = fileHash)
 
     val result =
       InventoryTaskFileDownload.create(request)
@@ -450,7 +457,8 @@ class InventoryTaskFileDownloadTest {
         progressMajor = null,
         uri = URI.create("http://www.example.com/0.apk"),
         retries = 3,
-        outputFile = outputFile)
+        outputFile = outputFile,
+        expectedHash = fileHash)
 
     val result =
       InventoryTaskFileDownload.create(request)
@@ -526,7 +534,8 @@ class InventoryTaskFileDownloadTest {
         progressMajor = null,
         uri = URI.create("http://www.example.com/0.apk"),
         retries = 1,
-        outputFile = outputFile)
+        outputFile = outputFile,
+        expectedHash = fileHash)
 
     this.cancelled.set(true)
 


### PR DESCRIPTION
This change pertains to issue: #18 

@io7m I understand this is likely going to need some changes to make it "nice" - but the hashing has been inlined.