### PR TITLE
Store application data in externalFilesDir

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/AULFA/updater.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/AULFA/updater.git
 POM_SCM_URL=http://github.com/AULFA/updater/
 POM_URL=http://github.com/AULFA/updater/
-VERSION_NAME=0.0.4-SNAPSHOT
+VERSION_NAME=0.0.5-SNAPSHOT
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/one.lfa.updater.app/src/main/java/au/org/libraryforall/updater/app/MainBootServices.kt
+++ b/one.lfa.updater.app/src/main/java/au/org/libraryforall/updater/app/MainBootServices.kt
@@ -224,7 +224,7 @@ object MainBootServices {
   private fun createCatalogDirectory(context: Context): InventoryCatalogDirectoryType {
     return object : InventoryCatalogDirectoryType {
       override val directory: File
-        get() = File(context.filesDir, "OPDS")
+        get() = File(context.getExternalFilesDir(null) ?: context.filesDir, "OPDS")
     }
   }
 
@@ -251,7 +251,7 @@ object MainBootServices {
   }
 
   private fun apkDirectory(context: Context): File {
-    val dir1 = File(context.filesDir, "APKs").absoluteFile
+    val dir1 = File(context.getExternalFilesDir(null) ?: context.filesDir, "APKs").absoluteFile
     this.logger.debug("using internal files dir: {}", dir1)
     return dir1
   }
@@ -286,13 +286,13 @@ object MainBootServices {
   }
 
   private fun inventoryDatabaseDirectory(context: Context): File {
-    val dir = File(context.filesDir, "Repositories").absoluteFile
+    val dir = File(context.getExternalFilesDir(null) ?: context.filesDir, "Repositories").absoluteFile
     this.logger.debug("using inventory directory: {}", dir)
     return dir
   }
 
   private fun opdsDatabaseDirectory(context: Context): File {
-    val dir = File(context.filesDir, "OPDS").absoluteFile
+    val dir = File(context.getExternalFilesDir(null) ?: context.filesDir, "OPDS").absoluteFile
     this.logger.debug("using OPDS database directory: {}", dir)
     return dir
   }

--- a/one.lfa.updater.app/version.properties
+++ b/one.lfa.updater.app/version.properties
@@ -1,3 +1,3 @@
 #
-#Mon Feb 15 11:31:11 UTC 2021
-versionCode=1412
+#Wed Dec 08 15:04:40 AEDT 2021
+versionCode=1413


### PR DESCRIPTION
Use the `externalFilesDir` directory to store downloaded and generated data of the application.
Fall back to `filesDir` if `externalFilesDir` is not available.