### PR TITLE
Load additional OPDS feeds from external storage during boot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ static def sha256Of(File file) {
 task preFlightChecks {
   logger.info("running pre-flight checks")
 
-  def keystoreHash = "20dfb53906594f4ae7a77df3d92f87f1c003c6a824b0b541c23c3185fd603da8"
+  def keystoreHash = "df23e1d756802f420a8add6d6104848a4ae110d5de946267cccb9ea8b2e892dd"
 
   def requiredFiles = [:]
   requiredFiles["lfa-keystore.jks"] = keystoreHash

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ POM_SCM_CONNECTION=scm:git:git://github.com/AULFA/updater.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/AULFA/updater.git
 POM_SCM_URL=http://github.com/AULFA/updater/
 POM_URL=http://github.com/AULFA/updater/
-VERSION_NAME=0.0.6-SNAPSHOT
+VERSION_NAME=0.0.7-SNAPSHOT
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/one.lfa.updater.app/version.properties
+++ b/one.lfa.updater.app/version.properties
@@ -1,3 +1,3 @@
 #
-#Fri Jan 21 15:21:47 AEDT 2022
-versionCode=1438
+#Thu May 19 19:52:30 AEST 2022
+versionCode=1487

--- a/one.lfa.updater.inclusiv/version.properties
+++ b/one.lfa.updater.inclusiv/version.properties
@@ -1,3 +1,3 @@
 #
-#Fri Jan 21 15:21:47 AEDT 2022
-versionCode=1438
+#Thu May 19 19:52:30 AEST 2022
+versionCode=1487

--- a/one.lfa.updater.main/version.properties
+++ b/one.lfa.updater.main/version.properties
@@ -1,3 +1,3 @@
 #
-#Fri Jan 21 15:21:47 AEDT 2022
-versionCode=1438
+#Thu May 19 19:52:31 AEST 2022
+versionCode=1487


### PR DESCRIPTION
We've recently discovered that some devices with Android 11 don't support creating or pushing content in the apps' external files directories through ADB. The main issue is that some devices (in our case, the Samsung Tablet A8) don't set the correct user and/or permissions automatically upon pushing content on the external files directories.
This is a quick hack to allow providing pre-installed OPDS feeds for the Updater by pushing the files to a public directory on the device's external storage. The primary use case is as follows:
1. During kit production, we push the feeds to the `/sdcard/LFA/au.org.libraryforall.updater.app/files/OPDS` directory on the device.
2. The `android.permission.READ_EXTERNAL_STORAGE` and `android.permission.WRITE_EXTERNAL_STORAGE` permissions are granted either through script or manually.
3. The Updater is then started, either through script or manually.
4. The Updater looks for the `/sdcard/LFA/au.org.libraryforall.updater.app/files/OPDS` directory. If it exists and it's accessible, the Updater copies the directory on its own external files directory (`/sdcard/Android/data/au.org.libraryforall.updater.app/files/OPDS`) and deletes the original.

Note that any failure during the copy or deletion of the files doesn't stop the Updater from booting. However, it may result in that content not being available to the reader app(s).

cc @ddawsonlfa @TheSunShower 